### PR TITLE
Add support for NZ suburbs to address autocomplete feature POC

### DIFF
--- a/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
+++ b/src/app/address/googleAutocomplete/AddressSelectorFactory.ts
@@ -1,4 +1,5 @@
 import AddressSelector from './AddressSelector';
+import AddressSelectorNZ from './AddressSelectorNz';
 import AddressSelectorUK from './AddressSelectorUk';
 
 export default class AddressSelectorFactory {
@@ -8,6 +9,9 @@ export default class AddressSelectorFactory {
         switch (addressSelector.getCountry()) {
         case 'GB':
             return new AddressSelectorUK(autocompleteData);
+
+        case 'NZ':
+            return new AddressSelectorNZ(autocompleteData);
         }
 
         return addressSelector;

--- a/src/app/address/googleAutocomplete/AddressSelectorNz.ts
+++ b/src/app/address/googleAutocomplete/AddressSelectorNz.ts
@@ -1,0 +1,10 @@
+import AddressSelector from './AddressSelector';
+
+export default class AddressSelectorNZ extends AddressSelector {
+    getCity(): string {
+        return this._get('postal_town', 'long_name') ||
+            this._get('sublocality', 'long_name') ||
+            this._get('locality', 'long_name') ||
+            this._get('neighborhood', 'short_name');
+    }
+}

--- a/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
+++ b/src/app/address/googleAutocomplete/googleAutocompleteTypes.ts
@@ -44,6 +44,7 @@ export type GoogleAddressFieldType =
     'administrative_area_level_1' |
     'administrative_area_level_2' |
     'locality' |
+    'sublocality' |
     'neighborhood' |
     'postal_code' |
     'street_number' |


### PR DESCRIPTION
[New Zealand addressing standards](https://www.nzpost.co.nz/business/shipping-in-nz/addressing-standards) vary slightly from those found in the USA and Australia. As a result of this variation, when the Google Maps API returns an address from the autosuggest list, the suburb for an NZ address is returned in the component called `sublocality` instead of `locality`.

This pull-request extends the Google address autocomplete feature for NZ addresses by incorporating the sublocality address component.

These changes do not update the shipping address form labels to better match the New Zealand address standards but it might make sense to update those labels for NZ, e.g.:

![address-autocomplete](https://user-images.githubusercontent.com/106573/153951030-38bbcb62-8dac-4dbe-9a26-849a9f1ad02a.png)

